### PR TITLE
prevents double running the loop

### DIFF
--- a/src/functions/useRafFn/useRafFn.ts
+++ b/src/functions/useRafFn/useRafFn.ts
@@ -62,6 +62,7 @@ export function useRafFn(
   }
 
   const start = () => {
+    if(isRunning.value) return
     isRunning.value = true
     requestAnimationFrame(loop)
   }


### PR DESCRIPTION
runOnMount is set to true by default, so if you just instance it with a callback and then run `start()` then the loop would be running double. See https://github.com/davedbase/solid-primitives/pull/73